### PR TITLE
Fix incorrect number of blocks in a round

### DIFF
--- a/TechnicalWhitePaper.md
+++ b/TechnicalWhitePaper.md
@@ -116,7 +116,7 @@ EOS.IO software utilizes the only known decentralized consensus algorithm proven
 
 The EOS.IO software enables blocks to be produced exactly every 0.5 second and exactly one producer is authorized to produce a block at any given point in time. If the block is not produced at the scheduled time, then the block for that time slot is skipped. When one or more blocks are skipped, there is a 0.5 or more second gap in the blockchain.
 
-Using the EOS.IO software, blocks are produced in rounds of 126 (6 blocks each, times 21 producers). At the start of each round 21 unique block producers are chosen by preference of votes cast by token holders. The selected producers are scheduled in an order agreed upon by 15 or more producers.
+Using the EOS.IO software, blocks are produced in rounds of 252 (12 blocks each, times 21 producers). At the start of each round 21 unique block producers are chosen by preference of votes cast by token holders. The selected producers are scheduled in an order agreed upon by 15 or more producers.
 
 If a producer misses a block and has not produced any block within the last 24 hours they are removed from consideration until they notify the blockchain of their intention to start producing blocks again. This ensures the network operates smoothly by minimizing the number of blocks missed by not scheduling producers who are proven to be unreliable.
 


### PR DESCRIPTION
Producers are actually producing 12 blocks per turn, not 6.